### PR TITLE
Disable Add Event button when input fields are empty

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,9 +9,9 @@
 <h1>College Event Manager</h1>
 
 <div class="form">
-  <input id="eventName" placeholder="Event name">
-  <input id="eventDate" type="date">
-  <button onclick="addEvent()" id="addBtn">Add Event</button>
+  <input id="eventName" placeholder="Event name" oninput="checkInputs()">
+  <input id="eventDate" type="date" oninput="checkInputs()">
+  <button onclick="addEvent()" id="addBtn" disabled>Add Event</button>
 </div>
 
 <ul id="eventList"></ul>

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 <div class="form">
   <input id="eventName" placeholder="Event name">
   <input id="eventDate" type="date">
-  <button onclick="addEvent()">Add Event</button>
+  <button onclick="addEvent()" id="addBtn">Add Event</button>
 </div>
 
 <ul id="eventList"></ul>

--- a/script.js
+++ b/script.js
@@ -45,4 +45,3 @@ function deleteEvent(index) {
   }
 
 }
-

--- a/script.js
+++ b/script.js
@@ -24,6 +24,17 @@ function renderEvents() {
     list.appendChild(li)
   })
 }
+function checkInputs(){
+  let name=document.getElementById("eventName").value
+  let date=document.getElementById("eventDate").value
+  let addBtn=document.getElementById("addBtn")
+  if(name.trim()!=="" && date.trim()!==""){
+    addBtn.disabled=false
+  }else{
+    addBtn.disabled=true
+  }
+}
+
 
 function deleteEvent(index) {
   let confirmDel=confirm("Are you sure you want to delete this event? ")

--- a/script.js
+++ b/script.js
@@ -34,3 +34,4 @@ function deleteEvent(index) {
   }
 
 }
+


### PR DESCRIPTION
This PR improves form validation by disabling the "Add Event" button when required input fields are empty.

Changes made:
- Add button remains disabled when event name or date is empty
- Button automatically enables when both fields are filled
- Prevents accidental empty event submissions
- Improves user experience and input validation

Fixes #17 